### PR TITLE
Delete duplicate method

### DIFF
--- a/src/s3c/object.clj
+++ b/src/s3c/object.clj
@@ -115,9 +115,6 @@
        (.getObject (client/lookup))
        (.getObjectAsString)))
 
-(defn delete [bucket key]
-  (.delete-object (client/lookup) bucket key))
-
 (defn bucket-exists? [bucket]
   (.doesBucketExist (client/lookup) bucket))
 


### PR DESCRIPTION
This duplicates another delete function and refers to a nonexistent method