### PR TITLE
generate pre-signed S3 URLs

### DIFF
--- a/src/s3c/core.clj
+++ b/src/s3c/core.clj
@@ -48,8 +48,10 @@
 
 (defn generate-presigned-url
   "Returns a pre-signed URL for accessing an Amazon S3 resource"
+  ([bucket key]
+   (generate-presigned-url bucket key nil))
   ([bucket key expiration-date]
-   (generate-presigned-url bucket key expiration-date :get))
+   (generate-presigned-url bucket key expiration-date nil))
   ([bucket key expiration-date http-method]
    (error-as-value
     (ob/generate-presigned-url bucket key expiration-date http-method))))

--- a/src/s3c/core.clj
+++ b/src/s3c/core.clj
@@ -46,6 +46,14 @@
 (defn url [bucket key]
   (ob/s3-url bucket key))
 
+(defn generate-presigned-url
+  "Returns a pre-signed URL for accessing an Amazon S3 resource"
+  ([bucket key expiration-date]
+   (generate-presigned-url bucket key expiration-date :get))
+  ([bucket key expiration-date http-method]
+   (error-as-value
+    (ob/generate-presigned-url bucket key expiration-date http-method))))
+
 (defn put-str [bucket key text]
   (let [stream   (stream/str->stream text)
         metadata {:content-type "text"}]

--- a/src/s3c/object.clj
+++ b/src/s3c/object.clj
@@ -8,6 +8,7 @@
    [s3c.client :as client]
    [s3c.acl :as acl])
   (:import
+   (com.amazonaws HttpMethod)
    (com.amazonaws.services.s3.model
     ListObjectsV2Request
     GetObjectRequest
@@ -136,3 +137,13 @@
          (.withPrefix prefix))
        (.listObjectsV2 (client/lookup))
        (.getCommonPrefixes)))
+
+(defn generate-presigned-url [bucket key expiration-time http-method]
+  (let [method (HttpMethod/valueOf (-> http-method
+                                       name
+                                       str/upper-case))]
+    (.generatePresignedUrl (client/lookup)
+                           bucket
+                           key
+                           expiration-time
+                           method)))

--- a/src/s3c/object.clj
+++ b/src/s3c/object.clj
@@ -150,5 +150,5 @@
                                         str/upper-case))
          request (cond-> (GeneratePresignedUrlRequest. bucket key)
                    expiration-date (.withExpiration expiration-date)
-                   http-method     (.withMethod http-method))]
+                   method          (.withMethod method))]
      (.generatePresignedUrl (client/lookup) request))))


### PR DESCRIPTION
Useful to allow clients to read or upload to a bucket without sharing
credentials